### PR TITLE
🔖Allow generating plain comments via the identifier trick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2019-MM-DD
+
+### Changed
+
+- Adding support for plain Rust comments via special `quote!`-able struct `sourcegen_cli::tokens::PlainComment`.
+
+[0.3.3]: https://github.com/commure/sourcegen/releases/tag/sourcegen-cli-v0.3.3
+
 ## [0.3.2] - 2019-08-21
 
 ### Changed

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ harness = false
 [dependencies]
 syn = { version = "1.0.0", features = ["full"] }
 proc-macro2 = { version = "1.0.0", features = ["span-locations"] }
+quote = "1.0.0"
 cargo_metadata = "0.8.1"
 failure = "0.1.5"
 tempfile = "3.0.8"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -17,6 +17,7 @@ mod mods;
 mod normalize;
 mod region;
 mod rustfmt;
+pub mod tokens;
 
 /// Trait to be implemented by source generators.
 pub trait SourceGenerator {

--- a/cli/src/tokens.rs
+++ b/cli/src/tokens.rs
@@ -1,0 +1,32 @@
+use proc_macro2::{Ident, Span, TokenStream, TokenTree};
+
+pub(crate) const MAGIC_IDENT: &str = "__SOURCEGEN_MAGIC_COMMENT__";
+
+/// Token used to generate plain Rust comments in the output. Used as a marker in front of the
+/// string literal to generate a plain comment. Usage:
+///
+/// ```rust
+/// use sourcegen_cli::tokens::PlainComment;
+/// let _output = quote::quote! {
+///     #PlainComment "GeneratedComment"
+///     struct Test;
+/// };
+/// ```
+///
+/// Generated output will contain a plain comment:
+/// ```
+/// // Generated comment
+/// struct Test;
+/// ```
+pub struct PlainComment;
+
+impl PlainComment {}
+
+impl quote::ToTokens for PlainComment {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(std::iter::once(TokenTree::Ident(Ident::new(
+            MAGIC_IDENT,
+            Span::call_site(),
+        ))));
+    }
+}

--- a/cli/tests/generators/mod.rs
+++ b/cli/tests/generators/mod.rs
@@ -1,6 +1,7 @@
 use failure::Error;
 use proc_macro2::TokenStream;
 use quote::quote;
+use sourcegen_cli::tokens::PlainComment;
 use sourcegen_cli::SourceGenerator;
 
 /// Writes back the input without any changes
@@ -109,6 +110,27 @@ impl SourceGenerator for GenerateFile {
         Ok(Some(quote! {
             #[doc = r" Some generated comment here"]
             struct Hello {
+                pub hello: String,
+            }
+        }))
+    }
+}
+
+/// Generates a struct with regular comments
+pub struct GeneratePlainComments;
+
+impl SourceGenerator for GeneratePlainComments {
+    fn generate_struct(
+        &self,
+        _args: syn::AttributeArgs,
+        item: &syn::ItemStruct,
+    ) -> Result<Option<TokenStream>, Error> {
+        let vis = &item.vis;
+        let ident = &item.ident;
+        Ok(Some(quote! {
+            #PlainComment "This is some struct!"
+            #vis struct #ident {
+                #PlainComment "This is some field!"
                 pub hello: String,
             }
         }))

--- a/cli/tests/suite.rs
+++ b/cli/tests/suite.rs
@@ -37,6 +37,10 @@ fn parameters(manifest: &Path) -> SourcegenParameters {
                 "generate-doc-comments",
                 &self::generators::GenerateDocComments,
             ),
+            (
+                "generate-plain-comments",
+                &self::generators::GeneratePlainComments,
+            ),
             ("generate-file", &self::generators::GenerateFile),
         ],
         ..Default::default()

--- a/cli/tests/test_data/007-plain-comments/expected/Cargo.toml
+++ b/cli/tests/test_data/007-plain-comments/expected/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[dependencies]
+sourcegen = { path = "../../fake_sourcegen" }
+
+[workspace]

--- a/cli/tests/test_data/007-plain-comments/expected/src/lib.rs
+++ b/cli/tests/test_data/007-plain-comments/expected/src/lib.rs
@@ -1,0 +1,7 @@
+#[sourcegen::sourcegen(generator = "generate-plain-comments")]
+// Generated. All manual edits to the block annotated with #[sourcegen...] will be discarded.
+// This is some struct!
+struct Hello {
+    // This is some field!
+    pub hello: String,
+}

--- a/cli/tests/test_data/007-plain-comments/input/Cargo.toml
+++ b/cli/tests/test_data/007-plain-comments/input/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[dependencies]
+sourcegen = { path = "../../fake_sourcegen" }
+
+[workspace]

--- a/cli/tests/test_data/007-plain-comments/input/src/lib.rs
+++ b/cli/tests/test_data/007-plain-comments/input/src/lib.rs
@@ -1,0 +1,3 @@
+#[sourcegen::sourcegen(generator = "generate-plain-comments")]
+// Generated. All manual edits to the block annotated with #[sourcegen...] will be discarded.
+struct Hello;


### PR DESCRIPTION
Adding a struct that can be `quote!`-ed to produce a plain Rust comment.
Internally, it generates a magic identifier and a string literal after
it. When we render token stream, we match on this identifier and
append a plain Rust comment to the output stream (and then let the
`rustfmt` to do the formatting in the end).

Closes #3